### PR TITLE
experimental navigation refinements

### DIFF
--- a/react-native/Fable.Helpers.ReactNative.fs
+++ b/react-native/Fable.Helpers.ReactNative.fs
@@ -597,12 +597,12 @@ module Props =
         interface ITextStyle
 
     [<KeyValueList>]
-    type ITextProperties =
+    type ITextPropertiesIOS =
         interface end
 
     [<KeyValueList>]
-    type ITextPropertiesIOS =
-        inherit ITextProperties
+    type ITextProperties =
+        inherit ITextPropertiesIOS
         
     [<KeyValueList>]
     type TextPropertiesIOS =
@@ -622,16 +622,17 @@ module Props =
         interface ITextProperties
 
     [<KeyValueList>]
-    type ITextInputProperties =
+    type ITextInputIOSProperties =
         interface end
 
     [<KeyValueList>]
-    type ITextInputIOSProperties =
-        inherit ITextInputProperties
+    type ITextInputAndroidProperties =
+        interface end
 
     [<KeyValueList>]
-    type ITextInputAndroidProperties =
-        inherit ITextInputProperties
+    type ITextInputProperties =
+        inherit ITextInputIOSProperties
+        inherit ITextInputAndroidProperties
 
     module TextInput = 
         [<KeyValueList>]
@@ -1496,16 +1497,32 @@ module Props =
 
 
     [<KeyValueList>]
-    type NavigationHeaderProps =
-        | RenderTitleComponent of (obj -> React.ReactElement<obj>)
-        | OnNavigateBack of (unit -> unit)
+    type INavigationHeaderProps =
+        interface end
 
+    [<KeyValueList>]
+    type NavigationHeaderProps =
+        | RenderTitleComponent of (NavigationTransitionProps -> React.ReactElement<obj>)
+        | RenderLeftComponent of (NavigationTransitionProps -> React.ReactElement<obj>)
+        | RenderRightComponent of (NavigationTransitionProps -> React.ReactElement<obj>)
+        | StatusBarHeight of U2<float,Animated.Value>
+        | OnNavigateBack of (unit -> unit)
+        interface INavigationHeaderProps
+
+    [<KeyValueList>]
+    type INavigationCardStackProps =
+        interface end
 
     [<KeyValueList>]
     type NavigationCardStackProps =
         | Direction of Direction
         | Style of IStyle list
-        | Route of obj
+        | EnableGestures of bool
+        | GestureResponseDistance of float
+        | CardStyle of IStyle list
+        | RenderHeader of (NavigationTransitionProps -> React.ReactElement<obj>)
+        | OnNavigateBack of (unit -> unit)
+        interface INavigationCardStackProps
 
     [<KeyValueList>]
     type IBreadcrumbNavigationBarProperties =
@@ -1680,7 +1697,7 @@ let inline imageWithChild (props: IImageProperties list) (child: React.ReactElem
         unbox props,
         unbox([|child|])) |> unbox        
 
-let inline listView<'a> (dataSource:ListViewDataSource<'a>) (props: ListViewProperties<'a> list)  : React.ReactElement<obj> =
+let inline listView<'a> (dataSource:ListViewDataSource<'a>) (props: IListViewProperties list)  : React.ReactElement<obj> =
     React.createElement(
         RN.ListView, 
         JS.Object.assign(
@@ -1701,11 +1718,11 @@ let inline modal (props:ModalProperties list) : React.ReactElement<obj> =
       unbox props,
       unbox([||])) |> unbox
 
-let inline touchableWithoutFeedback (props:ITouchableWithoutFeedbackProperties list) : React.ReactElement<obj> = 
+let inline touchableWithoutFeedback (props:ITouchableWithoutFeedbackProperties list) (children: React.ReactElement<obj> list): React.ReactElement<obj> = 
     React.createElement(
       RN.TouchableWithoutFeedback,
       unbox props,
-      unbox([||])) |> unbox
+      unbox(List.toArray children)) |> unbox
 
 let inline touchableHighlight (props:ITouchableHighlightProperties list) (children: React.ReactElement<obj> list) : React.ReactElement<obj> = 
     React.createElement(
@@ -1719,17 +1736,17 @@ let inline touchableHighlightWithChild (props:ITouchableHighlightProperties list
       unbox props,
       unbox([|child|])) |> unbox
 
-let inline touchableOpacity (props:ITouchableOpacityProperties list) : React.ReactElement<obj> = 
+let inline touchableOpacity (props:ITouchableOpacityProperties list) (children: React.ReactElement<obj> list): React.ReactElement<obj> = 
     React.createElement(
       RN.TouchableOpacity,
       unbox props,
-      unbox([||])) |> unbox
+      unbox(List.toArray children)) |> unbox
 
-let inline touchableNativeFeedback (props:TouchableNativeFeedbackProperties list) : React.ReactElement<obj> = 
+let inline touchableNativeFeedback (props:ITouchableNativeFeedbackProperties list) (children: React.ReactElement<obj> list): React.ReactElement<obj> = 
     React.createElement(
       RN.TouchableNativeFeedback,
       unbox props,
-      unbox([||])) |> unbox
+      unbox(List.toArray children)) |> unbox
 
 let inline viewPagerAndroid (props: IViewPagerAndroidProperties list) (children: React.ReactElement<obj> list) : React.ReactElement<obj> =
     React.createElement(
@@ -1785,10 +1802,10 @@ let inline switch (props:ISwitchProperties list) : React.ReactElement<obj> =
       unbox props,
       unbox([||])) |> unbox
 
-let inline navigationHeader (props:NavigationHeaderProps list) : React.ReactElement<obj> = 
+let inline navigationHeader (props:INavigationHeaderProps list) (rendererProps:NavigationTransitionProps): React.ReactElement<obj> =
     React.createElement(
       RN.NavigationExperimental.Header,
-      unbox props,
+      JS.Object.assign(props,rendererProps) |> unbox,
       unbox([||])) |> unbox
 
 let inline navigationState (index:int) (routes:NavigationRoute list) =
@@ -1803,14 +1820,12 @@ let inline navigationRoute (key:string) (title:string option) =
     
 let inline navigationCardStack (navigationState: NavigationState)
                                (renderScene: NavigationTransitionProps -> React.ReactElement<obj>)
-                               (onNavigateBack: unit -> unit)
-                               (props:NavigationCardStackProps list): React.ReactElement<obj> = 
+                               (props:INavigationCardStackProps list): React.ReactElement<obj> = 
     React.createElement(
       RN.NavigationExperimental.CardStack,
       JS.Object.assign(
             createObj ["renderScene" ==> renderScene
-                       "navigationState" ==> navigationState
-                       "onNavigateBack" ==> onNavigateBack],
+                       "navigationState" ==> navigationState],
             props)
         |> unbox,
       unbox([||])) |> unbox

--- a/react-native/Fable.Import.ReactNative.fs
+++ b/react-native/Fable.Import.ReactNative.fs
@@ -1938,15 +1938,15 @@ module ReactNative =
 
     and NavigationState =
         inherit NavigationRoute
-        abstract index: float with get, set
-        abstract routes: ResizeArray<NavigationRoute> with get, set
+        abstract index: int with get, set
+        abstract routes: Array<NavigationRoute> with get, set
         abstract isMeasured: bool with get, set
 
     and NavigationScene =
         abstract key: string with get, set
         abstract isActive: bool with get, set
         abstract isStale: bool with get, set
-        abstract index: float with get, set
+        abstract index: int with get, set
         abstract route: NavigationRoute with get, set
 
     and NavigationTransitionProps =
@@ -1991,12 +1991,26 @@ module ReactNative =
     and NavigationCardStackStatic =
         inherit React.ComponentClass<NavigationCardStackProps>
 
+    // added by hand from JS sources
+    and NavigationStateUtilsStatic =
+        abstract get: state: NavigationState*key: string -> NavigationRoute option
+        abstract indexOf: state: NavigationState * key: string -> int
+        abstract has: state: NavigationState * key: string -> bool
+        abstract push: state: NavigationState * route: NavigationRoute -> NavigationState
+        abstract pop: state: NavigationState -> NavigationState
+        abstract jumpToIndex: state: NavigationState * index: int -> NavigationState
+        abstract jumpTo: state: NavigationState * key: string -> NavigationState
+        abstract forward: state: NavigationState -> NavigationState 
+        abstract replaceAt: state: NavigationState * key: string * route: NavigationRoute -> NavigationState
+        abstract replaceAtIndex: state: NavigationState * index: int * route: NavigationRoute -> NavigationState
+        abstract reset: state: NavigationState * routes: Array<NavigationRoute> * index: int option -> NavigationState
 
     and NavigationExperimentalStatic =
         abstract AnimatedView: NavigationAnimatedViewStatic with get, set
         abstract CardStack: NavigationCardStackStatic with get, set
         abstract Header: NavigationHeaderStatic with get, set
         abstract Reducer: NavigationReducerStatic with get, set
+        abstract StateUtils: NavigationStateUtilsStatic with get, set
 
     and NavigationContainerProps =
         abstract tabs: ResizeArray<NavigationTab> with get, set


### PR DESCRIPTION
Inferring from JS sources the properties for cardStack, header and utils.

Breaking: all "touchable" constructors now take children.

Also, addressing some missed opportunities for covariance of props.