### PR TITLE
Remove (text: string) arg from TextInput

### DIFF
--- a/src/react-native/Fable.Helpers.ReactNative.fs
+++ b/src/react-native/Fable.Helpers.ReactNative.fs
@@ -1546,8 +1546,8 @@ let inline internal createElement(c: React.ComponentClass<'T>, props: obj, child
 let text (props:TextProperties list) (text:string): React.ReactElement =
     createElement(RN.Text, props, [React.str text])
 
-let textInput (props: ITextInputProperties list) (text:string): React.ReactElement =
-    createElement(RN.TextInput, props, [R.str text])
+let textInput (props: ITextInputProperties list) : React.ReactElement =
+    createElement(RN.TextInput, props, [])
 
 let createToolbarAction(title:string,showStatus:ToolbarActionShowStatus) : ToolbarAndroidAction =
     createObj [


### PR DESCRIPTION
TextInput cannot have child elements and the text should set in the props rather than in the children. According to a user on gitter:
> When I try to make use of TextInput, passing it an arbitrary string, I get "Raw text cannot be used outside of a <Text> tag. Not rendering string: "foo""

He confirmed that using this alternative works:
```fsharp
let textInput (props: ITextInputProperties list) : React.ReactElement  =
        R.from (RN.TextInput) (unbox props) []
```
Which is the same as 
```fsharp
let textInput (props: ITextInputProperties list) : React.ReactElement  =
       createElement(RN.TextInput, props, [])
```
