### PR TITLE
SVGAttr attribute Height added to match Width

### DIFF
--- a/src/Fable.React/Fable.Helpers.React.fs
+++ b/src/Fable.React/Fable.Helpers.React.fs
@@ -257,6 +257,7 @@ module Props =
         | Fy of obj
         | GradientTransform of string
         | GradientUnits of string
+        | Height of obj
         | MarkerEnd of string
         | MarkerMid of string
         | MarkerStart of string


### PR DESCRIPTION
Unless I'm missing something, it's hard to make an SVG rectangle without a Height tag.  There is a matching Width attribute.  Also useful for specifying the SVG element's size as well.  Apologies if I'm missing something deeper.