### PR TITLE
New uniform names for helpers

### DIFF
--- a/src/Fable.React/Fable.Helpers.React.fs
+++ b/src/Fable.React/Fable.Helpers.React.fs
@@ -583,22 +583,64 @@ module Props =
 
 open Props
 open Fable.Import.React
-open Fable.Core.JsInterop
 
 [<Import("createElement", from="react")>]
-let createElement(componentClass: obj, props: obj, [<ParamList>] children: obj) = jsNative
+let createElement(component: obj, props: obj, [<ParamList>] children: obj) = jsNative
 
-/// Instantiate a React component from a type inheriting React.Component<>
+/// OBSOLETE: Use `ofType`
+[<System.Obsolete("Use ofType")>]
 let inline com<'T,[<Pojo>]'P,[<Pojo>]'S when 'T :> Component<'P,'S>> (props: 'P) (children: ReactElement list): ReactElement =
     createElement(typedefof<'T>, props, children)
 
-/// Instantiate a stateless component from a function
+/// OBSOLETE: Use `ofFunction`
+[<System.Obsolete("Use ofFunction")>]
 let inline fn<[<Pojo>]'P> (f: 'P -> ReactElement) (props: 'P) (children: ReactElement list): ReactElement =
     createElement(f, props, children)
 
 /// Instantiate an imported React component
 let inline from<[<Pojo>]'P> (com: ComponentClass<'P>) (props: 'P) (children: ReactElement list): ReactElement =
     createElement(com, props, children)
+
+/// Instantiate a component from a type inheriting React.Component
+/// Example: `ofType<MyComponent,_,_> { myProps = 5 } []`
+let inline ofType<'T,[<Pojo>]'P,[<Pojo>]'S when 'T :> Component<'P,'S>> (props: 'P) (children: ReactElement list): ReactElement =
+    createElement(typedefof<'T>, props, children)
+
+/// Instantiate a stateless component from a function
+/// Example:
+/// ```
+/// let Hello (p: MyProps) = div [] [ofString ("Hello " + p.name)]
+/// ofFunction Hello { name = "Maxime" } []
+/// ```
+let inline ofFunction<[<Pojo>]'P> (f: 'P -> ReactElement) (props: 'P) (children: ReactElement list): ReactElement =
+    createElement(f, props, children)
+
+/// Instantiate an imported React component. The first two arguments must be string literals, "default" can be used for the first one.
+/// Example: `ofImported "Map" "leaflet" { x = 10; y = 50 } []`
+let inline ofImported<[<Pojo>]'P> (importMember: string) (importPath: string) (props: 'P) (children: ReactElement list): ReactElement =
+    createElement(import importMember importPath, props, children)
+
+/// OBSOLETE: Use `ofString`
+[<System.Obsolete("Use ofString")>]
+let inline str (s: string): ReactElement = unbox s
+/// OBSOLETE: Use `ofOption`
+[<System.Obsolete("Use ofOption")>]
+let inline opt (o: ReactElement option): ReactElement = unbox o
+
+/// Cast a string to a React element (erased in runtime)
+let inline ofString (s: string): ReactElement = unbox s
+/// Cast an option value to a React element (erased in runtime)
+let inline ofOption (o: ReactElement option): ReactElement = unbox o
+
+/// Cast an int to a React element (erased in runtime)
+let inline ofInt (i: int): ReactElement = unbox i
+/// Cast a float to a React element (erased in runtime)
+let inline ofFloat (f: float): ReactElement = unbox f
+
+/// Returns a list **from .render() method**
+let inline ofList (els: ReactElement list): ReactElement = unbox(List.toArray els)
+/// Returns an array **from .render() method**
+let inline ofArray (els: ReactElement list): ReactElement = unbox els
 
 /// Instantiate a DOM React element
 let inline domEl (tag: string) (props: IHTMLProp list) (children: ReactElement list): ReactElement =
@@ -612,7 +654,7 @@ let inline voidEl (tag: string) (props: IHTMLProp list) : ReactElement =
 let inline svgEl (tag: string) (props: IProp list) (children: ReactElement list): ReactElement =
     createElement(tag, keyValueList CaseRules.LowerFirst props, children)
 
-// Standard element
+// Standard elements
 let inline a b c = domEl "a" b c
 let inline abbr b c = domEl "abbr" b c
 let inline address b c = domEl "address" b c
@@ -750,28 +792,6 @@ let inline stop b c = svgEl "stop" b c
 let inline text b c = svgEl "text" b c
 let inline tspan b c = svgEl "tspan" b c
 
-/// Cast a string to a React element (erased in runtime)
-[<System.Obsolete("Use ofString")>]
-let inline str (s: string): ReactElement = unbox s
-/// Cast an option value to a React element (erased in runtime)
-[<System.Obsolete("Use ofOption")>]
-let inline opt (o: ReactElement option): ReactElement = unbox o
-
-/// Cast a string to a React element (erased in runtime)
-let inline ofString (s: string): ReactElement = unbox s
-/// Cast an option value to a React element (erased in runtime)
-let inline ofOption (o: ReactElement option): ReactElement = unbox o
-
-/// Cast an int to a React element (erased in runtime)
-let inline ofInt (i: int): ReactElement = unbox i
-/// Cast a float to a React element (erased in runtime)
-let inline ofFloat (f: float): ReactElement = unbox f
-
-/// Returns a list **from .render() method**
-let inline ofList (els: ReactElement list): ReactElement = unbox(List.toArray els)
-/// Returns an array **from .render() method**
-let inline ofArray (els: ReactElement list): ReactElement = unbox els
-
 // Class list helpers
 let classBaseList std classes =
     classes
@@ -839,6 +859,6 @@ let reactiveCom<'P, 'S, 'Msg>
         (key: string)
         (props: 'P)
         (children: ReactElement list): ReactElement =
-    com<ReactiveCom<'P, 'S, 'Msg>, Props<'P, 'S, 'Msg>, State<'S>>
+    ofType<ReactiveCom<'P, 'S, 'Msg>, Props<'P, 'S, 'Msg>, State<'S>>
         { key=key; props=props; update=update; view=view; init=init }
         children

--- a/src/Fable.React/Fable.Helpers.React.fs
+++ b/src/Fable.React/Fable.Helpers.React.fs
@@ -616,21 +616,24 @@ let inline ofFunction<[<Pojo>]'P> (f: 'P -> ReactElement) (props: 'P) (children:
     createElement(f, props, children)
 
 /// Instantiate an imported React component. The first two arguments must be string literals, "default" can be used for the first one.
-/// Example: `ofImported "Map" "leaflet" { x = 10; y = 50 } []`
-let inline ofImported<[<Pojo>]'P> (importMember: string) (importPath: string) (props: 'P) (children: ReactElement list): ReactElement =
+/// Example: `ofImport "Map" "leaflet" { x = 10; y = 50 } []`
+let inline ofImport<[<Pojo>]'P> (importMember: string) (importPath: string) (props: 'P) (children: ReactElement list): ReactElement =
     createElement(import importMember importPath, props, children)
 
-/// OBSOLETE: Use `ofString`
-[<System.Obsolete("Use ofString")>]
+/// Alias of `ofString`
 let inline str (s: string): ReactElement = unbox s
-/// OBSOLETE: Use `ofOption`
-[<System.Obsolete("Use ofOption")>]
-let inline opt (o: ReactElement option): ReactElement = unbox o
 
 /// Cast a string to a React element (erased in runtime)
 let inline ofString (s: string): ReactElement = unbox s
+
+/// OBSOLETE: Use `ofOption`
+[<System.Obsolete("Use ofOption")>]
+let inline opt (o: ReactElement option): ReactElement =
+    match o with Some o -> o | None -> null
+
 /// Cast an option value to a React element (erased in runtime)
-let inline ofOption (o: ReactElement option): ReactElement = unbox o
+let inline ofOption (o: ReactElement option): ReactElement =
+    match o with Some o -> o | None -> null // Option.toObj(o)
 
 /// Cast an int to a React element (erased in runtime)
 let inline ofInt (i: int): ReactElement = unbox i

--- a/src/Fable.React/Fable.Import.React.fs
+++ b/src/Fable.React/Fable.Import.React.fs
@@ -9,7 +9,7 @@ module React =
     type ReactType =
         U3<string, ComponentClass<obj>, StatelessComponent<obj>>
 
-    and ReactElement =
+    and [<AllowNullLiteral>] ReactElement =
         interface end
 
     and ClassicElement<'P> =

--- a/src/Fable.React/Fable.Import.React.fs
+++ b/src/Fable.React/Fable.Import.React.fs
@@ -62,6 +62,20 @@ module React =
     and ReactInstance =
         U2<Component<obj, obj>, Element>
 
+    /// Create a React component by inheriting this class as follows
+    ///
+    /// ```
+    /// type MyComponent(props) =
+    ///     inherit React.Component<MyProps, MyState>(props)
+    ///     base.setInitState({ value = 5 })
+    ///
+    ///     override this.render() =
+    ///         // Don't use captured `props` from constructor,
+    ///         // use `this.props` instead (updated version)
+    ///         let msg = sprintf "Hello %s, you have %i €"
+    ///                     this.props.name this.state.value
+    ///         div [] [ofString msg]
+    /// ```
     and [<AbstractClass; Import("Component", "react")>] Component<[<Pojo>]'P, [<Pojo>]'S>(props: 'P) =
         [<Emit("$0.props")>]
         member __.props: 'P = jsNative
@@ -71,23 +85,23 @@ module React =
 
         [<Emit("$0.state")>]
         member __.state: 'S = jsNative
-        [<Emit("$0.setState($1)")>]
 
         /// ATTENTION: Within the constructor, use `setInitState`
         /// Enqueues changes to the component state and tells React that this component and its children need to be re-rendered with the updated state. This is the primary method you use to update the user interface in response to event handlers and server responses.
         /// Think of setState() as a request rather than an immediate command to update the component. For better perceived performance, React may delay it, and then update several components in a single pass. React does not guarantee that the state changes are applied immediately.
         /// setState() does not always immediately update the component. It may batch or defer the update until later. This makes reading this.state right after calling setState() a potential pitfall. Instead, use componentDidUpdate or a setState callback (setState(updater, callback)), either of which are guaranteed to fire after the update has been applied. If you need to set the state based on the previous state, read about the updater argument below.
         /// setState() will always lead to a re-render unless shouldComponentUpdate() returns false. If mutable objects are being used and conditional rendering logic cannot be implemented in shouldComponentUpdate(), calling setState() only when the new state differs from the previous state will avoid unnecessary re-renders.
-        member __.setState(value: 'S): unit = jsNative
         [<Emit("$0.setState($1)")>]
+        member __.setState(value: 'S): unit = jsNative
 
         /// Overload of `setState` accepting updater function with the signature: `(prevState, props) => stateChange`
         /// prevState is a reference to the previous state. It should not be directly mutated. Instead, changes should be represented by building a new object based on the input from prevState and props.
         /// Both prevState and props received by the updater function are guaranteed to be up-to-date. The output of the updater is shallowly merged with prevState.
+        [<Emit("$0.setState($1)")>]
         member __.setState(updater: 'S->'P->'S): unit = jsNative
-        [<Emit("this.state = $1")>]
 
         /// This method can only be called in the constructor
+        [<Emit("this.state = $1")>]
         member __.setInitState(value: 'S): unit = jsNative
 
         /// By default, when your component’s state or props change, your component will re-render. If your render() method depends on some other data, you can tell React that the component needs re-rendering by calling forceUpdate().


### PR DESCRIPTION
At the beginning I wrote the helper names to be as short as possible (`com` to instantiate a component from a type, `fn` from a function, `str` from string, etc). But I think this is confusing for new users and React allows more types to be accepted as elements or as the return value of `render()` (numbers, arrays...).

We're going to introduce some breaking changes in 1.3 (now you'll have to use `override` for the `render()` method) so maybe it's good time to try to uniform the helpers API. I was thinking to use more meaningful names prefixed by `of`. The old names would still be valid but they would be marked as obsolete so users can update them. What do you think? @forki @MangelMaxime @et1975 @zaaack 

```
ofType
ofFunction
ofImported
ofString
ofOption
ofInt
ofArray
...
```