### PR TITLE
Add BoxShadow CSSProp

### DIFF
--- a/src/Fable.React/Fable.Helpers.React.fs
+++ b/src/Fable.React/Fable.Helpers.React.fs
@@ -380,6 +380,7 @@ module Props =
         | BoxLineProgression of obj
         | BoxLines of obj
         | BoxOrdinalGroup of obj
+        | BoxShadow of obj
         | BreakAfter of obj
         | BreakBefore of obj
         | BreakInside of obj


### PR DESCRIPTION
When I tried to write inline style for box-shadow css property, I found out that it is missing in CSSProp discriminated union. So here is a fix.