### PR TITLE
Added many CSS props sourced from MDN. Changed all CSS types to obj.

### DIFF
--- a/src/Fable.React/Fable.Helpers.React.fs
+++ b/src/Fable.React/Fable.Helpers.React.fs
@@ -312,56 +312,71 @@ module Props =
         interface IProp
 
     type CSSProp =
-        | BoxFlex of float
-        | BoxFlexGroup of float
-        | ColumnCount of float
-        | Cursor of string
-        | Flex of obj
-        | FlexGrow of float
-        | FlexShrink of float
-        | FontWeight of obj
-        | LineClamp of float
-        | LineHeight of obj
-        | Opacity of float
-        | Order of float
-        | Orphans of float
-        | Widows of float
-        | ZIndex of float
-        | Zoom of float
-        | FontSize of obj
-        | FillOpacity of float
-        | StrokeOpacity of float
-        | StrokeWidth of float
         | AlignContent of obj
         | AlignItems of obj
         | AlignSelf of obj
         | AlignmentAdjust of obj
         | AlignmentBaseline of obj
+        | All of obj
+        | Animation of obj
         | AnimationDelay of obj
         | AnimationDirection of obj
+        | AnimationDuration of obj
+        | AnimationFillMode of obj
         | AnimationIterationCount of obj
         | AnimationName of obj
         | AnimationPlayState of obj
+        | AnimationTimingFunction of obj
         | Appearance of obj
         | BackfaceVisibility of obj
+        | Background of obj
+        | BackgroundAttachment of obj
         | BackgroundBlendMode of obj
+        | BackgroundClip of obj
         | BackgroundColor of obj
         | BackgroundComposite of obj
         | BackgroundImage of obj
         | BackgroundOrigin of obj
+        | BackgroundPosition of obj
         | BackgroundPositionX of obj
+        | BackgroundPositionY of obj
         | BackgroundRepeat of obj
+        | BackgroundSize of obj
         | BaselineShift of obj
         | Behavior of obj
+        | BlockSize of obj
         | Border of obj
+        | BorderBlockEnd of obj
+        | BorderBlockEndColor of obj
+        | BorderBlockEndStyle of obj
+        | BorderBlockEndWidth of obj
+        | BorderBlockStart of obj
+        | BorderBlockStartColor of obj
+        | BorderBlockStartStyle of obj
+        | BorderBlockStartWidth of obj
+        | BorderBottom of obj
+        | BorderBottomColor of obj
         | BorderBottomLeftRadius of obj
         | BorderBottomRightRadius of obj
+        | BorderBottomStyle of obj
         | BorderBottomWidth of obj
         | BorderCollapse of obj
         | BorderColor of obj
         | BorderCornerShape of obj
+        | BorderImage of obj
+        | BorderImageOutset of obj
+        | BorderImageRepeat of obj
+        | BorderImageSlice of obj
         | BorderImageSource of obj
         | BorderImageWidth of obj
+        | BorderInlineEnd of obj
+        | BorderInlineEndColor of obj
+        | BorderInlineEndStyle of obj
+        | BorderInlineEndWidth of obj
+        | BorderInlineStart of obj
+        | BorderInlineStartColor of obj
+        | BorderInlineStartStyle of obj
+        | BorderInlineStartWidth of obj
         | BorderLeft of obj
         | BorderLeftColor of obj
         | BorderLeftStyle of obj
@@ -384,71 +399,121 @@ module Props =
         | BoxAlign of obj
         | BoxDecorationBreak of obj
         | BoxDirection of obj
+        | BoxFlex of obj
+        | BoxFlexGroup of obj
         | BoxLineProgression of obj
         | BoxLines of obj
         | BoxOrdinalGroup of obj
         | BoxShadow of obj
+        | BoxSizing of obj
         | BreakAfter of obj
         | BreakBefore of obj
         | BreakInside of obj
+        | CaptionSide of obj
+        | CaretColor of obj
         | Clear of obj
         | Clip of obj
+        | ClipPath of obj
         | ClipRule of obj
         | Color of obj
+        | ColorInterpolation of obj
+        | ColorInterpolationFilters of obj
+        | ColorProfile of obj
+        | ColorRendering of obj
+        | ColumnCount of obj
         | ColumnFill of obj
         | ColumnGap of obj
         | ColumnRule of obj
         | ColumnRuleColor of obj
+        | ColumnRuleStyle of obj
         | ColumnRuleWidth of obj
         | ColumnSpan of obj
         | ColumnWidth of obj
         | Columns of obj
+        | Content of obj
         | CounterIncrement of obj
         | CounterReset of obj
         | Cue of obj
         | CueAfter of obj
+        | Cursor of obj
         | Direction of obj
         | Display of obj
+        | DominantBaseline of obj
+        | EmptyCells of obj
+        | EnableBackground of obj
         | Fill of obj
+        | FillOpacity of obj
         | FillRule of obj
         | Filter of obj
+        | Flex of obj
         | FlexAlign of obj
         | FlexBasis of obj
         | FlexDirection of obj
         | FlexFlow of obj
+        | FlexGrow of obj
         | FlexItemAlign of obj
         | FlexLinePack of obj
         | FlexOrder of obj
+        | FlexShrink of obj
         | FlexWrap of obj
         | Float of obj
+        | FloodColor of obj
+        | FloodOpacity of obj
         | FlowFrom of obj
         | Font of obj
         | FontFamily of obj
+        | FontFeatureSettings of obj
         | FontKerning of obj
+        | FontLanguageOverride of obj
+        | FontSize of obj
         | FontSizeAdjust of obj
         | FontStretch of obj
         | FontStyle of obj
         | FontSynthesis of obj
         | FontVariant of obj
         | FontVariantAlternates of obj
+        | FontVariantCaps of obj
+        | FontVariantEastAsian of obj
+        | FontVariantLigatures of obj
+        | FontVariantNumeric of obj
+        | FontVariantPosition of obj
+        | FontWeight of obj
+        | GlyphOrientationHorizontal of obj
+        | GlyphOrientationVertical of obj
+        | Grid of obj
         | GridArea of obj
+        | GridAutoColumns of obj
+        | GridAutoFlow of obj
+        | GridAutoRows of obj
         | GridColumn of obj
         | GridColumnEnd of obj
+        | GridColumnGap of obj
         | GridColumnStart of obj
+        | GridGap of obj
         | GridRow of obj
         | GridRowEnd of obj
+        | GridRowGap of obj
         | GridRowPosition of obj
         | GridRowSpan of obj
+        | GridRowStart of obj
+        | GridTemplate of obj
         | GridTemplateAreas of obj
         | GridTemplateColumns of obj
         | GridTemplateRows of obj
+        | HangingPunctuation of obj
         | Height of obj
         | HyphenateLimitChars of obj
         | HyphenateLimitLines of obj
         | HyphenateLimitZone of obj
         | Hyphens of obj
+        | ImageOrientation of obj
+        | ImageRendering of obj
+        | ImageResolution of obj
         | ImeMode of obj
+        | InlineSize of obj
+        | Isolation of obj
         | JustifyContent of obj
+        | Kerning of obj
         | LayoutGrid of obj
         | LayoutGridChar of obj
         | LayoutGridLine of obj
@@ -456,16 +521,26 @@ module Props =
         | LayoutGridType of obj
         | Left of obj
         | LetterSpacing of obj
+        | LightingColor of obj
         | LineBreak of obj
+        | LineClamp of obj
+        | LineHeight of obj
         | ListStyle of obj
         | ListStyleImage of obj
         | ListStylePosition of obj
         | ListStyleType of obj
         | Margin of obj
+        | MarginBlockEnd of obj
+        | MarginBlockStart of obj
         | MarginBottom of obj
+        | MarginInlineEnd of obj
+        | MarginInlineStart of obj
         | MarginLeft of obj
         | MarginRight of obj
         | MarginTop of obj
+        | MarkerEnd of obj
+        | MarkerMid of obj
+        | MarkerStart of obj
         | MarqueeDirection of obj
         | MarqueeStyle of obj
         | Mask of obj
@@ -475,21 +550,47 @@ module Props =
         | MaskBorderSource of obj
         | MaskBorderWidth of obj
         | MaskClip of obj
+        | MaskComposite of obj
+        | MaskImage of obj
+        | MaskMode of obj
         | MaskOrigin of obj
+        | MaskPosition of obj
+        | MaskRepeat of obj
+        | MaskSize of obj
+        | MaskType of obj
         | MaxFontSize of obj
         | MaxHeight of obj
         | MaxWidth of obj
+        | MinBlockSize of obj
         | MinHeight of obj
+        | MinInlineSize of obj
         | MinWidth of obj
+        | MixBlendMode of obj
+        | ObjectFit of obj
+        | ObjectPosition of obj
+        | OffsetBlockEnd of obj
+        | OffsetBlockStart of obj
+        | OffsetInlineEnd of obj
+        | OffsetInlineStart of obj
+        | Opacity of obj
+        | Order of obj
+        | Orphans of obj
         | Outline of obj
         | OutlineColor of obj
         | OutlineOffset of obj
+        | OutlineStyle of obj
+        | OutlineWidth of obj
         | Overflow of obj
         | OverflowStyle of obj
+        | OverflowWrap of obj
         | OverflowX of obj
         | OverflowY of obj
         | Padding of obj
+        | PaddingBlockEnd of obj
+        | PaddingBlockStart of obj
         | PaddingBottom of obj
+        | PaddingInlineEnd of obj
+        | PaddingInlineStart of obj
         | PaddingLeft of obj
         | PaddingRight of obj
         | PaddingTop of obj
@@ -506,21 +607,40 @@ module Props =
         | PunctuationTrim of obj
         | Quotes of obj
         | RegionFragment of obj
+        | Resize of obj
         | RestAfter of obj
         | RestBefore of obj
         | Right of obj
         | RubyAlign of obj
+        | RubyMerge of obj
         | RubyPosition of obj
+        | ScrollBehavior of obj
+        | ScrollSnapCoordinate of obj
+        | ScrollSnapDestination of obj
+        | ScrollSnapType of obj
         | ShapeImageThreshold of obj
         | ShapeInside of obj
         | ShapeMargin of obj
         | ShapeOutside of obj
+        | ShapeRendering of obj
         | Speak of obj
         | SpeakAs of obj
+        | StopColor of obj
+        | StopOpacity of obj
+        | Stroke of obj
+        | StrokeDasharray of obj
+        | StrokeDashoffset of obj
+        | StrokeLinecap of obj
+        | StrokeLinejoin of obj
+        | StrokeMiterlimit of obj
+        | StrokeOpacity of obj
+        | StrokeWidth of obj
         | TabSize of obj
         | TableLayout of obj
         | TextAlign of obj
         | TextAlignLast of obj
+        | TextAnchor of obj
+        | TextCombineUpright of obj
         | TextDecoration of obj
         | TextDecorationColor of obj
         | TextDecorationLine of obj
@@ -532,9 +652,11 @@ module Props =
         | TextDecorationUnderline of obj
         | TextEmphasis of obj
         | TextEmphasisColor of obj
+        | TextEmphasisPosition of obj
         | TextEmphasisStyle of obj
         | TextHeight of obj
         | TextIndent of obj
+        | TextJustify of obj
         | TextJustifyTrim of obj
         | TextKashidaSpace of obj
         | TextLineThrough of obj
@@ -542,6 +664,7 @@ module Props =
         | TextLineThroughMode of obj
         | TextLineThroughStyle of obj
         | TextLineThroughWidth of obj
+        | TextOrientation of obj
         | TextOverflow of obj
         | TextOverline of obj
         | TextOverlineColor of obj
@@ -557,6 +680,7 @@ module Props =
         | Top of obj
         | TouchAction of obj
         | Transform of obj
+        | TransformBox of obj
         | TransformOrigin of obj
         | TransformOriginZ of obj
         | TransformStyle of obj
@@ -581,7 +705,9 @@ module Props =
         | VoiceVolume of obj
         | WhiteSpace of obj
         | WhiteSpaceTreatment of obj
+        | Widows of obj
         | Width of obj
+        | WillChange of obj
         | WordBreak of obj
         | WordSpacing of obj
         | WordWrap of obj
@@ -589,6 +715,8 @@ module Props =
         | WrapMargin of obj
         | WrapOption of obj
         | WritingMode of obj
+        | ZIndex of obj
+        | Zoom of obj
         interface ICSSProp
 
 open Props

--- a/src/Fable.React/Fable.Import.React.fs
+++ b/src/Fable.React/Fable.Import.React.fs
@@ -490,59 +490,76 @@ module React =
         abstract onTransitionEnd: TransitionEventHandler option with get, set
 
     and CSSProperties =
-        abstract boxFlex: float option with get, set
-        abstract boxFlexGroup: float option with get, set
-        abstract columnCount: float option with get, set
-        abstract flex: U2<float, string> option with get, set
-        abstract flexGrow: float option with get, set
-        abstract flexShrink: float option with get, set
-        abstract fontWeight: U2<float, string> option with get, set
-        abstract lineClamp: float option with get, set
-        abstract lineHeight: U2<float, string> option with get, set
-        abstract opacity: float option with get, set
-        abstract order: float option with get, set
-        abstract orphans: float option with get, set
-        abstract widows: float option with get, set
-        abstract zIndex: float option with get, set
-        abstract zoom: float option with get, set
-        abstract fontSize: U2<float, string> option with get, set
-        abstract fillOpacity: float option with get, set
-        abstract strokeOpacity: float option with get, set
-        abstract strokeWidth: float option with get, set
         abstract alignContent: obj option with get, set
         abstract alignItems: obj option with get, set
         abstract alignSelf: obj option with get, set
         abstract alignmentAdjust: obj option with get, set
         abstract alignmentBaseline: obj option with get, set
+        abstract all: obj option with get, set
+        abstract animation: obj option with get, set
         abstract animationDelay: obj option with get, set
         abstract animationDirection: obj option with get, set
+        abstract animationDuration: obj option with get, set
+        abstract animationFillMode: obj option with get, set
         abstract animationIterationCount: obj option with get, set
         abstract animationName: obj option with get, set
         abstract animationPlayState: obj option with get, set
+        abstract animationTimingFunction: obj option with get, set
         abstract appearance: obj option with get, set
         abstract backfaceVisibility: obj option with get, set
+        abstract background: obj option with get, set
+        abstract backgroundAttachment: obj option with get, set
         abstract backgroundBlendMode: obj option with get, set
+        abstract backgroundClip: obj option with get, set
         abstract backgroundColor: obj option with get, set
         abstract backgroundComposite: obj option with get, set
         abstract backgroundImage: obj option with get, set
         abstract backgroundOrigin: obj option with get, set
+        abstract backgroundPosition: obj option with get, set
         abstract backgroundPositionX: obj option with get, set
+        abstract backgroundPositionY: obj option with get, set
         abstract backgroundRepeat: obj option with get, set
+        abstract backgroundSize: obj option with get, set
         abstract baselineShift: obj option with get, set
         abstract behavior: obj option with get, set
+        abstract blockSize: obj option with get, set
         abstract border: obj option with get, set
+        abstract borderBlockEnd: obj option with get, set
+        abstract borderBlockEndColor: obj option with get, set
+        abstract borderBlockEndStyle: obj option with get, set
+        abstract borderBlockEndWidth: obj option with get, set
+        abstract borderBlockStart: obj option with get, set
+        abstract borderBlockStartColor: obj option with get, set
+        abstract borderBlockStartStyle: obj option with get, set
+        abstract borderBlockStartWidth: obj option with get, set
+        abstract borderBottom: obj option with get, set
+        abstract borderBottomColor: obj option with get, set
         abstract borderBottomLeftRadius: obj option with get, set
         abstract borderBottomRightRadius: obj option with get, set
+        abstract borderBottomStyle: obj option with get, set
         abstract borderBottomWidth: obj option with get, set
         abstract borderCollapse: obj option with get, set
         abstract borderColor: obj option with get, set
         abstract borderCornerShape: obj option with get, set
+        abstract borderImage: obj option with get, set
+        abstract borderImageOutset: obj option with get, set
+        abstract borderImageRepeat: obj option with get, set
+        abstract borderImageSlice: obj option with get, set
         abstract borderImageSource: obj option with get, set
         abstract borderImageWidth: obj option with get, set
+        abstract borderInlineEnd: obj option with get, set
+        abstract borderInlineEndColor: obj option with get, set
+        abstract borderInlineEndStyle: obj option with get, set
+        abstract borderInlineEndWidth: obj option with get, set
+        abstract borderInlineStart: obj option with get, set
+        abstract borderInlineStartColor: obj option with get, set
+        abstract borderInlineStartStyle: obj option with get, set
+        abstract borderInlineStartWidth: obj option with get, set
         abstract borderLeft: obj option with get, set
         abstract borderLeftColor: obj option with get, set
         abstract borderLeftStyle: obj option with get, set
         abstract borderLeftWidth: obj option with get, set
+        abstract borderRadius: obj option with get, set
         abstract borderRight: obj option with get, set
         abstract borderRightColor: obj option with get, set
         abstract borderRightStyle: obj option with get, set
@@ -560,70 +577,121 @@ module React =
         abstract boxAlign: obj option with get, set
         abstract boxDecorationBreak: obj option with get, set
         abstract boxDirection: obj option with get, set
+        abstract boxFlex: obj option with get, set
+        abstract boxFlexGroup: obj option with get, set
         abstract boxLineProgression: obj option with get, set
         abstract boxLines: obj option with get, set
         abstract boxOrdinalGroup: obj option with get, set
+        abstract boxShadow: obj option with get, set
+        abstract boxSizing: obj option with get, set
         abstract breakAfter: obj option with get, set
         abstract breakBefore: obj option with get, set
         abstract breakInside: obj option with get, set
+        abstract captionSide: obj option with get, set
+        abstract caretColor: obj option with get, set
         abstract clear: obj option with get, set
         abstract clip: obj option with get, set
+        abstract clipPath: obj option with get, set
         abstract clipRule: obj option with get, set
         abstract color: obj option with get, set
+        abstract colorInterpolation: obj option with get, set
+        abstract colorInterpolationFilters: obj option with get, set
+        abstract colorProfile: obj option with get, set
+        abstract colorRendering: obj option with get, set
+        abstract columnCount: obj option with get, set
         abstract columnFill: obj option with get, set
         abstract columnGap: obj option with get, set
         abstract columnRule: obj option with get, set
         abstract columnRuleColor: obj option with get, set
+        abstract columnRuleStyle: obj option with get, set
         abstract columnRuleWidth: obj option with get, set
         abstract columnSpan: obj option with get, set
         abstract columnWidth: obj option with get, set
         abstract columns: obj option with get, set
+        abstract content: obj option with get, set
         abstract counterIncrement: obj option with get, set
         abstract counterReset: obj option with get, set
         abstract cue: obj option with get, set
         abstract cueAfter: obj option with get, set
+        abstract cursor: obj option with get, set
         abstract direction: obj option with get, set
         abstract display: obj option with get, set
+        abstract dominantBaseline: obj option with get, set
+        abstract emptyCells: obj option with get, set
+        abstract enableBackground: obj option with get, set
         abstract fill: obj option with get, set
+        abstract fillOpacity: obj option with get, set
         abstract fillRule: obj option with get, set
         abstract filter: obj option with get, set
+        abstract flex: obj option with get, set
         abstract flexAlign: obj option with get, set
         abstract flexBasis: obj option with get, set
         abstract flexDirection: obj option with get, set
         abstract flexFlow: obj option with get, set
+        abstract flexGrow: obj option with get, set
         abstract flexItemAlign: obj option with get, set
         abstract flexLinePack: obj option with get, set
         abstract flexOrder: obj option with get, set
+        abstract flexShrink: obj option with get, set
         abstract flexWrap: obj option with get, set
         abstract float: obj option with get, set
+        abstract floodColor: obj option with get, set
+        abstract floodOpacity: obj option with get, set
         abstract flowFrom: obj option with get, set
         abstract font: obj option with get, set
         abstract fontFamily: obj option with get, set
+        abstract fontFeatureSettings: obj option with get, set
         abstract fontKerning: obj option with get, set
+        abstract fontLanguageOverride: obj option with get, set
+        abstract fontSize: obj option with get, set
         abstract fontSizeAdjust: obj option with get, set
         abstract fontStretch: obj option with get, set
         abstract fontStyle: obj option with get, set
         abstract fontSynthesis: obj option with get, set
         abstract fontVariant: obj option with get, set
         abstract fontVariantAlternates: obj option with get, set
+        abstract fontVariantCaps: obj option with get, set
+        abstract fontVariantEastAsian: obj option with get, set
+        abstract fontVariantLigatures: obj option with get, set
+        abstract fontVariantNumeric: obj option with get, set
+        abstract fontVariantPosition: obj option with get, set
+        abstract fontWeight: obj option with get, set
+        abstract glyphOrientationHorizontal: obj option with get, set
+        abstract glyphOrientationVertical: obj option with get, set
+        abstract grid: obj option with get, set
         abstract gridArea: obj option with get, set
+        abstract gridAutoColumns: obj option with get, set
+        abstract gridAutoFlow: obj option with get, set
+        abstract gridAutoRows: obj option with get, set
         abstract gridColumn: obj option with get, set
         abstract gridColumnEnd: obj option with get, set
+        abstract gridColumnGap: obj option with get, set
         abstract gridColumnStart: obj option with get, set
+        abstract gridGap: obj option with get, set
         abstract gridRow: obj option with get, set
         abstract gridRowEnd: obj option with get, set
+        abstract gridRowGap: obj option with get, set
         abstract gridRowPosition: obj option with get, set
         abstract gridRowSpan: obj option with get, set
+        abstract gridRowStart: obj option with get, set
+        abstract gridTemplate: obj option with get, set
         abstract gridTemplateAreas: obj option with get, set
         abstract gridTemplateColumns: obj option with get, set
         abstract gridTemplateRows: obj option with get, set
+        abstract hangingPunctuation: obj option with get, set
         abstract height: obj option with get, set
         abstract hyphenateLimitChars: obj option with get, set
         abstract hyphenateLimitLines: obj option with get, set
         abstract hyphenateLimitZone: obj option with get, set
         abstract hyphens: obj option with get, set
+        abstract imageOrientation: obj option with get, set
+        abstract imageRendering: obj option with get, set
+        abstract imageResolution: obj option with get, set
         abstract imeMode: obj option with get, set
+        abstract inlineSize: obj option with get, set
+        abstract isolation: obj option with get, set
         abstract justifyContent: obj option with get, set
+        abstract kerning: obj option with get, set
         abstract layoutGrid: obj option with get, set
         abstract layoutGridChar: obj option with get, set
         abstract layoutGridLine: obj option with get, set
@@ -631,16 +699,26 @@ module React =
         abstract layoutGridType: obj option with get, set
         abstract left: obj option with get, set
         abstract letterSpacing: obj option with get, set
+        abstract lightingColor: obj option with get, set
         abstract lineBreak: obj option with get, set
+        abstract lineClamp: obj option with get, set
+        abstract lineHeight: obj option with get, set
         abstract listStyle: obj option with get, set
         abstract listStyleImage: obj option with get, set
         abstract listStylePosition: obj option with get, set
         abstract listStyleType: obj option with get, set
         abstract margin: obj option with get, set
+        abstract marginBlockEnd: obj option with get, set
+        abstract marginBlockStart: obj option with get, set
         abstract marginBottom: obj option with get, set
+        abstract marginInlineEnd: obj option with get, set
+        abstract marginInlineStart: obj option with get, set
         abstract marginLeft: obj option with get, set
         abstract marginRight: obj option with get, set
         abstract marginTop: obj option with get, set
+        abstract markerEnd: obj option with get, set
+        abstract markerMid: obj option with get, set
+        abstract markerStart: obj option with get, set
         abstract marqueeDirection: obj option with get, set
         abstract marqueeStyle: obj option with get, set
         abstract mask: obj option with get, set
@@ -650,20 +728,47 @@ module React =
         abstract maskBorderSource: obj option with get, set
         abstract maskBorderWidth: obj option with get, set
         abstract maskClip: obj option with get, set
+        abstract maskComposite: obj option with get, set
+        abstract maskImage: obj option with get, set
+        abstract maskMode: obj option with get, set
         abstract maskOrigin: obj option with get, set
+        abstract maskPosition: obj option with get, set
+        abstract maskRepeat: obj option with get, set
+        abstract maskSize: obj option with get, set
+        abstract maskType: obj option with get, set
         abstract maxFontSize: obj option with get, set
         abstract maxHeight: obj option with get, set
         abstract maxWidth: obj option with get, set
+        abstract minBlockSize: obj option with get, set
         abstract minHeight: obj option with get, set
+        abstract minInlineSize: obj option with get, set
         abstract minWidth: obj option with get, set
+        abstract mixBlendMode: obj option with get, set
+        abstract objectFit: obj option with get, set
+        abstract objectPosition: obj option with get, set
+        abstract offsetBlockEnd: obj option with get, set
+        abstract offsetBlockStart: obj option with get, set
+        abstract offsetInlineEnd: obj option with get, set
+        abstract offsetInlineStart: obj option with get, set
+        abstract opacity: obj option with get, set
+        abstract order: obj option with get, set
+        abstract orphans: obj option with get, set
         abstract outline: obj option with get, set
         abstract outlineColor: obj option with get, set
         abstract outlineOffset: obj option with get, set
+        abstract outlineStyle: obj option with get, set
+        abstract outlineWidth: obj option with get, set
         abstract overflow: obj option with get, set
         abstract overflowStyle: obj option with get, set
+        abstract overflowWrap: obj option with get, set
         abstract overflowX: obj option with get, set
+        abstract overflowY: obj option with get, set
         abstract padding: obj option with get, set
+        abstract paddingBlockEnd: obj option with get, set
+        abstract paddingBlockStart: obj option with get, set
         abstract paddingBottom: obj option with get, set
+        abstract paddingInlineEnd: obj option with get, set
+        abstract paddingInlineStart: obj option with get, set
         abstract paddingLeft: obj option with get, set
         abstract paddingRight: obj option with get, set
         abstract paddingTop: obj option with get, set
@@ -680,21 +785,40 @@ module React =
         abstract punctuationTrim: obj option with get, set
         abstract quotes: obj option with get, set
         abstract regionFragment: obj option with get, set
+        abstract resize: obj option with get, set
         abstract restAfter: obj option with get, set
         abstract restBefore: obj option with get, set
         abstract right: obj option with get, set
         abstract rubyAlign: obj option with get, set
+        abstract rubyMerge: obj option with get, set
         abstract rubyPosition: obj option with get, set
+        abstract scrollBehavior: obj option with get, set
+        abstract scrollSnapCoordinate: obj option with get, set
+        abstract scrollSnapDestination: obj option with get, set
+        abstract scrollSnapType: obj option with get, set
         abstract shapeImageThreshold: obj option with get, set
         abstract shapeInside: obj option with get, set
         abstract shapeMargin: obj option with get, set
         abstract shapeOutside: obj option with get, set
+        abstract shapeRendering: obj option with get, set
         abstract speak: obj option with get, set
         abstract speakAs: obj option with get, set
+        abstract stopColor: obj option with get, set
+        abstract stopOpacity: obj option with get, set
+        abstract stroke: obj option with get, set
+        abstract strokeDasharray: obj option with get, set
+        abstract strokeDashoffset: obj option with get, set
+        abstract strokeLinecap: obj option with get, set
+        abstract strokeLinejoin: obj option with get, set
+        abstract strokeMiterlimit: obj option with get, set
+        abstract strokeOpacity: obj option with get, set
+        abstract strokeWidth: obj option with get, set
         abstract tabSize: obj option with get, set
         abstract tableLayout: obj option with get, set
         abstract textAlign: obj option with get, set
         abstract textAlignLast: obj option with get, set
+        abstract textAnchor: obj option with get, set
+        abstract textCombineUpright: obj option with get, set
         abstract textDecoration: obj option with get, set
         abstract textDecorationColor: obj option with get, set
         abstract textDecorationLine: obj option with get, set
@@ -706,9 +830,11 @@ module React =
         abstract textDecorationUnderline: obj option with get, set
         abstract textEmphasis: obj option with get, set
         abstract textEmphasisColor: obj option with get, set
+        abstract textEmphasisPosition: obj option with get, set
         abstract textEmphasisStyle: obj option with get, set
         abstract textHeight: obj option with get, set
         abstract textIndent: obj option with get, set
+        abstract textJustify: obj option with get, set
         abstract textJustifyTrim: obj option with get, set
         abstract textKashidaSpace: obj option with get, set
         abstract textLineThrough: obj option with get, set
@@ -716,6 +842,7 @@ module React =
         abstract textLineThroughMode: obj option with get, set
         abstract textLineThroughStyle: obj option with get, set
         abstract textLineThroughWidth: obj option with get, set
+        abstract textOrientation: obj option with get, set
         abstract textOverflow: obj option with get, set
         abstract textOverline: obj option with get, set
         abstract textOverlineColor: obj option with get, set
@@ -731,6 +858,7 @@ module React =
         abstract top: obj option with get, set
         abstract touchAction: obj option with get, set
         abstract transform: obj option with get, set
+        abstract transformBox: obj option with get, set
         abstract transformOrigin: obj option with get, set
         abstract transformOriginZ: obj option with get, set
         abstract transformStyle: obj option with get, set
@@ -755,7 +883,9 @@ module React =
         abstract voiceVolume: obj option with get, set
         abstract whiteSpace: obj option with get, set
         abstract whiteSpaceTreatment: obj option with get, set
+        abstract widows: obj option with get, set
         abstract width: obj option with get, set
+        abstract willChange: obj option with get, set
         abstract wordBreak: obj option with get, set
         abstract wordSpacing: obj option with get, set
         abstract wordWrap: obj option with get, set
@@ -763,6 +893,8 @@ module React =
         abstract wrapMargin: obj option with get, set
         abstract wrapOption: obj option with get, set
         abstract writingMode: obj option with get, set
+        abstract zIndex: obj option with get, set
+        abstract zoom: obj option with get, set
         [<Emit("$0[$1]{{=$2}}")>] abstract Item: propertyName: string -> obj with get, set
 
     and HTMLAttributes =


### PR DESCRIPTION
(Not sure if you'll want this per issues described below, but submitting at least for consideration/discussion.)

I noticed some fairly typical CSS properties like background-position/background-size weren't represented. Rather than spot-add them, I went ahead and scraped https://developer.mozilla.org/en-US/docs/Web/CSS/Reference and https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute for a more complete list.

Many are experimental/draft settings, but the original list already had some of those so I just left everything in. I'm not sure if the library wants to be in the business of judging what to include/exclude, or leave it to the user.

Note, I didn't test everything added, just a few I was interested in. I converted all hyphen separators to camelCase/PascalCase assuming that works universally, but if that assumption is not true then I guess there might be some invalid entries in that case.

I also converted the small number of float, string, and U2<float,string> types to obj. The floats prevent using the standard CSS "initial"/"unset"/etc. string values, and for the other types I'm not sure it makes sense with regard to consistency to have just a few arbitrary typed properties when everything else is obj. But it is a minor breaking change that might affect some users.

Finally I sorted the entries (so don't be alarmed at block of deletions in the file diff).