### PR TITLE
Adding DataTarget to HTML-Attributes

### DIFF
--- a/src/Fable.React/Fable.Helpers.React.fs
+++ b/src/Fable.React/Fable.Helpers.React.fs
@@ -201,6 +201,7 @@ module rec Props =
         | Coords of string
         | CrossOrigin of string
         // | Data of string
+        | [<CompiledName("data-target")>] DataTarget of string
         | [<CompiledName("data-toggle")>] DataToggle of string
         | DateTime of string
         | Default of bool

--- a/src/Fable.React/Fable.Helpers.ReactServer.fs
+++ b/src/Fable.React/Fable.Helpers.ReactServer.fs
@@ -499,6 +499,7 @@ let private renderHtmlAttr (attr: HTMLAttr): string =
   | Coords v -> strAttr "coords" v
   | CrossOrigin v -> strAttr "crossorigin" v
   // | Data v -> pair "data" v
+  | DataTarget v -> strAttr "data-target" v
   | DataToggle v -> strAttr "data-toggle" v
   | DateTime v -> strAttr "datetime" v
   | Default v -> boolAttr "default" v


### PR DESCRIPTION
This attribute is needed for server-side rendering to render a menu button on mobile phones. Would appreciate a dot release. Thanks

/cc @horstoeko