### PR TITLE
Fix netstandard1.6 & style mismatch with client (fix 82)

### DIFF
--- a/src/Fable.React/Fable.Helpers.ReactServer.fs
+++ b/src/Fable.React/Fable.Helpers.ReactServer.fs
@@ -37,7 +37,7 @@ let private cssProp (html:StringBuilder) (key: string) (value: obj) =
   match value with
   | :? int as v -> addUnit html key (string v)
   | :? float as v -> addUnit html key (string v)
-  | _ -> html.Append value |> ignore
+  | _ -> escapeHtml html (value.ToString()) |> ignore
 
   html.Append ';' |> ignore
 
@@ -615,7 +615,8 @@ let private renderHtmlAttr (html:StringBuilder) (attr: HTMLAttr) =
 
     for cssProp in cssList do
       renderCssProp html cssProp
-
+    if not(List.isEmpty cssList) then
+      html.Remove (html.Length - 1, 1) |> ignore
     html.Append '"' |> ignore
 
   | HTMLAttr.Custom (key, value) -> strAttr html (key.ToLower()) (string value)

--- a/src/Fable.React/Fable.React.fsproj
+++ b/src/Fable.React/Fable.React.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>3.1.0</Version>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Fable.Import.React.fs" />


### PR DESCRIPTION
Fix https://github.com/fable-compiler/fable-react/issues/82 via adding some compiler directives, it's strange that the ionide can also emit diagnosticses after I run `dotnet build` in Fable.React...

@alfonsogarciacaro @MangelMaxime Plz review, thx~