### PR TITLE
Fix namespace Fable.React => Fable.Helpers.React

### DIFF
--- a/docs/using-third-party-react-components.md
+++ b/docs/using-third-party-react-components.md
@@ -72,7 +72,7 @@ In the example of rc-progress, to declare a `progressLine` creation function tha
 
 ```fsharp
 open Fable.Core
-open Fable.React
+open Fable.Helpers.React
 open Fable.Import.React
 open Fable.Core.JsInterop
 


### PR DESCRIPTION
I was really confused for an embarrassingly long time ;D