### PR TITLE
Make castHTMLNode public for use with Raw.WriteTo

### DIFF
--- a/src/Fable.React/Fable.Helpers.ReactServer.fs
+++ b/src/Fable.React/Fable.Helpers.ReactServer.fs
@@ -719,11 +719,13 @@ let rec private addReactMark htmlNode =
     HTMLNode.List (nodes |> Seq.cast |> Seq.map addReactMark |> Seq.cast)
   | h -> h
 
-let inline private castHTMLNode (htmlNode: ReactElement): HTMLNode =
-  if isNull htmlNode then
-    HTMLNode.Empty
-  else
-    htmlNode :?> HTMLNode
+/// Cast a ReactElement safely to an HTMLNode.
+/// Returns an empty node if input is not an HTMLNode.
+let inline castHTMLNode (htmlNode: ReactElement): HTMLNode =
+  match htmlNode with
+  | :? HTMLNode as node -> node
+  | _ -> HTMLNode.Empty
+
 
 module Raw =
   /// Writes the nodes into a TextWriter. DOESN'T ADD `reactroot` attribute.


### PR DESCRIPTION
Raw.writeTo accepts a HTMLNode while constructed model outputs a ReactElement.


The code already provides a private castHTMLNode function for conversion.

This PR make it public to be used from the outside.


The implementation has also been changed to make it safer. Any non matching input now returns a HTMLNode.Empty instead of throwing an exception.
