### PR TITLE
Add React.memo

### DIFF
--- a/src/Fable.React/Fable.Helpers.React.fs
+++ b/src/Fable.React/Fable.Helpers.React.fs
@@ -909,9 +909,22 @@ type PropsEqualityComparison<'props> = 'props -> 'props -> bool
 /// component, and reuse the last rendered result.
 ///
 /// By default it will only shallowly compare complex objects in the props object. If you want control over the
-/// comparison, you can also provide a custom comparison function as the second argument.
+/// comparison, you can use `memoWith`.
 [<Import("memo", from="react")>]
-let memo<'props> (render: 'props -> ReactElement, areEqual: PropsEqualityComparison<'props> option) : ReactComponentType<'props> =
+let memo<'props> (render: 'props -> ReactElement) : ReactComponentType<'props> =
+    jsNative
+
+/// React.memo is a higher order component. It’s similar to React.PureComponent but for function components instead of
+/// classes.
+///
+/// If your function component renders the same result given the same props, you can wrap it in a call to React.memo
+/// for a performance boost in some cases by memoizing the result. This means that React will skip rendering the
+/// component, and reuse the last rendered result.
+///
+/// This version allow you to control the comparison used instead of the default shallow one by provide a custom
+/// comparison function as the second argument.
+[<Import("memo", from="react")>]
+let memoWith<'props> (render: 'props -> ReactElement, areEqual: PropsEqualityComparison<'props>) : ReactComponentType<'props> =
     jsNative
 
 /// Create a ReactElement to be rendered from an element type, props and children

--- a/src/Fable.React/Fable.Helpers.React.fs
+++ b/src/Fable.React/Fable.Helpers.React.fs
@@ -851,10 +851,8 @@ let inline fn<'P> (f: 'P -> ReactElement) (props: 'P) (children: ReactElement se
 let inline ofImport<'P> (importMember: string) (importPath: string) (props: 'P) (children: ReactElement seq): ReactElement =
     createElement(import importMember importPath, props, children)
 
-[<Erase>]
 type ReactElementType<'props> = interface end
 
-[<Erase>]
 type ReactComponentType<'props> =
     inherit ReactElementType<'props>
     abstract displayName: string option with get, set

--- a/src/Fable.React/Fable.Helpers.React.fs
+++ b/src/Fable.React/Fable.Helpers.React.fs
@@ -901,6 +901,10 @@ module ReactElementType =
 
 type PropsEqualityComparison<'props> = 'props -> 'props -> bool
 
+[<Import("memo", from="react")>]
+let private reactMemo<'props> (render: 'props -> ReactElement) : ReactComponentType<'props> =
+    jsNative
+
 /// React.memo is a higher order component. It’s similar to React.PureComponent but for function components instead of
 /// classes.
 ///
@@ -910,8 +914,12 @@ type PropsEqualityComparison<'props> = 'props -> 'props -> bool
 ///
 /// By default it will only shallowly compare complex objects in the props object. If you want control over the
 /// comparison, you can use `memoWith`.
+let memo<'props> (name: string) (render: 'props -> ReactElement) : ReactComponentType<'props> =
+    render?displayName <- name
+    reactMemo(render)
+
 [<Import("memo", from="react")>]
-let memo<'props> (render: 'props -> ReactElement) : ReactComponentType<'props> =
+let private reactMemoWith<'props> (render: 'props -> ReactElement, areEqual: PropsEqualityComparison<'props>) : ReactComponentType<'props> =
     jsNative
 
 /// React.memo is a higher order component. It’s similar to React.PureComponent but for function components instead of
@@ -922,10 +930,10 @@ let memo<'props> (render: 'props -> ReactElement) : ReactComponentType<'props> =
 /// component, and reuse the last rendered result.
 ///
 /// This version allow you to control the comparison used instead of the default shallow one by provide a custom
-/// comparison function as the second argument.
-[<Import("memo", from="react")>]
-let memoWith<'props> (render: 'props -> ReactElement, areEqual: PropsEqualityComparison<'props>) : ReactComponentType<'props> =
-    jsNative
+/// comparison function.
+let memoWith<'props> (name: string) (areEqual: PropsEqualityComparison<'props>) (render: 'props -> ReactElement) : ReactComponentType<'props> =
+    render?displayName <- name
+    reactMemoWith(render, areEqual)
 
 /// Create a ReactElement to be rendered from an element type, props and children
 let inline ofElementType<'props> (comp: ReactElementType<'props>) (props: 'props) (children: ReactElement seq): ReactElement =


### PR DESCRIPTION
It also add to the helper types the concept of a `ReactComponentType` (Something that can be passed to createElement). Some of the types exists in the typescript-imported part of the library but they aren't really adapted and try to handle lot of things that are now obsolete.

They will also be necessary to import `React.lazy`

I didn't add any higher level helpers but one I find useful is the capability to create a named memo without passing the comparer :

```fsharp
let namedMemo<'props> (name: string) (f: 'props -> ReactElement): ReactComponentType<'props> =
    f?displayName <- name
    memo(f, None)

// Usage
type HelloProps = { Name: string }
let helloWorldComponent = namedMemo "HelloWorld" (fun props ->
  span [] [str "Hello "; str props.Name]
)
let helloWorld name = ofElementType helloWorldComponent { Name = name } []
```

Should I add it too ?

PS: *No server-side rendering for now as I don't know how it should work.*

Fixes #111