### PR TITLE
Add nothing to react helpers

### DIFF
--- a/src/Fable.React/Fable.Helpers.React.fs
+++ b/src/Fable.React/Fable.Helpers.React.fs
@@ -878,6 +878,10 @@ let inline ofList (els: ReactElement list): ReactElement = unbox(List.toArray el
 /// Returns an array **from .render() method**
 let inline ofArray (els: ReactElement array): ReactElement = unbox els
 
+/// A ReactElement when you don't want to render anything (null in javascript)
+[<Emit("null")>]
+let nothing: ReactElement = jsNative
+
 #else
 /// Alias of `ofString`
 let inline str (s: string): ReactElement = HTMLNode.Text s :> ReactElement
@@ -904,6 +908,9 @@ let inline ofList (els: ReactElement list): ReactElement = HTMLNode.List els :> 
 
 /// Returns an array **from .render() method**
 let inline ofArray (els: ReactElement array): ReactElement = HTMLNode.List els :> ReactElement
+
+/// A ReactElement when you don't want to render anything (null in javascript)
+let nothing: ReactElement = HTMLNode.Empty :> ReactElement
 
 #endif
 


### PR DESCRIPTION
React use `null` to signal that nothing should be rendered, it could be done before with `ofOption None` but this add clearer alternative to generate this.


```fsharp
let render props =
	let details =
		match props.Details with
		| Some d -> strong [] [str (sprintf " (%s)")] d
		| None -> nothing
	span [] [ str props.Name; details ]
```