### PR TITLE
Simplify memo usage by default

### DIFF
--- a/src/Fable.React/Fable.Helpers.React.fs
+++ b/src/Fable.React/Fable.Helpers.React.fs
@@ -915,7 +915,7 @@ module ReactElementType =
     /// By default it will only shallowly compare complex objects in the props object. If you want control over the
     /// comparison, you can use `memoWith`.
     [<Import("memo", from="react")>]
-    let inline memo<'props> (render: 'props -> ReactElement) : ReactComponentType<'props> =
+    let memo<'props> (render: 'props -> ReactElement) : ReactComponentType<'props> =
         jsNative
 
     [<Import("memo", from="react")>]


### PR DESCRIPTION
This is a breaking change to memo and memoWith !

They become builder functions, producing functions that can be directly used in a render method and don't support children.

The high-level version are still available in the ReactElementType module for anyone wanting the more complete experience (Like children support, or later returning component types themselves to use in `lazy`).

Sample usage :
```fsharp
type HelloProps = { Name: string }
let hello = memo "Hello" <| fun { Name = name } ->
    span [str "Hello "; str name]

let view model =
    hello { Name = model.Name }
```