### PR TITLE
Name memo elements

### DIFF
--- a/src/Fable.React.FunctionComponent.fs
+++ b/src/Fable.React.FunctionComponent.fs
@@ -37,7 +37,14 @@ type FunctionComponent =
 #endif
         let elemType =
             match memoizeWith with
-            | Some areEqual -> ReactElementType.memoWith areEqual render
+            | Some areEqual ->
+                let memoElement = ReactElementType.memoWith areEqual render
+#if FABLE_COMPILER
+                match displayName with
+                | Some name -> memoElement?displayName <- "Memo(" + name + ")"
+                | None -> ()
+#endif
+                memoElement
             | None -> ReactElementType.ofFunction render
         fun props ->
             ReactElementType.create elemType props []


### PR DESCRIPTION
Memo when used with a comparison function create a named node
in the React debugger.

The node is named 'Memo' by default and we change it to
'Memo(displayName)' if a displayName is passed to FunctionComponent.Of

![image](https://user-images.githubusercontent.com/131878/56321272-8b1cf500-6166-11e9-8d46-b911add9ec81.png)
