### PR TITLE
Clarify what FunctionComponent.Of does

### DIFF
--- a/src/Fable.React.FunctionComponent.fs
+++ b/src/Fable.React.FunctionComponent.fs
@@ -26,6 +26,7 @@ type FunctionComponent =
             div [] [] // React.lazy is not compatible with SSR, so just use an empty div
 #endif
 
+    /// Creates a functional React component. Uses React.memo if `memoizeWith` is specified.
     static member Of(render: 'Props->ReactElement,
                        ?displayName: string,
                        ?memoizeWith: 'Props -> 'Props -> bool)


### PR DESCRIPTION
Reading through the [Fable.React 5 blog post](https://fable.io/blog/Announcing-Fable-React-5.html), I was confused by the fact that `React.memo` wasn't mentioned anywhere. Digging into the code, it seems to me that the new `FunctionComponent.Of` uses `React.memo` when `memoizeWith` is specified. I think it would be best to mention this is the function's documentation.