### PR TITLE
Npm packages metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,3 +258,4 @@ packages/
 .idea/
 *.sln.iml
 *.orig
+.ionide

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 5.3.0
+
+- Add npm dependency metadata to work with Femto
+
 ### 5.2.6
 
 - Fix #167: Add `withKey` argument to `FunctionComponent.Of`

--- a/src/Fable.React.fsproj
+++ b/src/Fable.React.fsproj
@@ -7,6 +7,12 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- <DefineConstants>$(DefineConstants);FABLE_COMPILER</DefineConstants> -->
   </PropertyGroup>
+  <PropertyGroup>
+    <NpmDependencies>
+        <NpmPackage Name="react" Version=">= 16.8.0" />
+        <NpmPackage Name="react-dom" Version=">= 16.8.0" />
+    </NpmDependencies>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Fable.React.fs" />
     <Compile Include="Fable.ReactDom.fs" />

--- a/src/Fable.React.fsproj
+++ b/src/Fable.React.fsproj
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <NpmDependencies>
         <NpmPackage Name="react" Version=">= 16.8.0" />
-        <NpmPackage Name="react-dom" Version=">= 16.8.0" />
     </NpmDependencies>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Packages validated with Femto locally, using version constraint `>= 16.8.0` because that is where React shipped hooks, downstream package [Fable.Elmish.React](https://github.com/elmish/react) will need an update too along with [Fable.ReactNative](https://github.com/fable-compiler/fable-react-native) because they both depend on this package

@alfonsogarciacaro @forki  @MangelMaxime 