### PR TITLE
Added JustifySelf used in Grid containers

### DIFF
--- a/src/Fable.React.Props.fs
+++ b/src/Fable.React.Props.fs
@@ -498,6 +498,34 @@ type AlignSelfOptions =
     | [<CompiledName "flex-end">] FlexEnd
 
 [<StringEnum; RequireQualifiedAccess>]
+/// Specifies the default alignment for items inside the grid container.
+type JustifySelfOptions =
+    /// Default. The element inherits its parent container's justify-items property, or "stretch" if it has no parent container.
+    | Auto
+    /// The element is positioned at the baseline of the cell.
+    | Baseline
+    /// The element is positioned to fit the cell.
+    | Stretch
+    /// The element is positioned at the center of the cell.
+    | Center
+    /// Sets this property to its default value. Read more about [CSS Initial](https://developer.mozilla.org/en-US/docs/Web/CSS/initial)
+    | Initial
+    /// Inherits this property from its parent element. Read about [CSS Inherit](https://developer.mozilla.org/en-US/docs/Web/CSS/inherit)
+    | Inherit
+    /// The element is positioned at the beginning of the cell.
+    | Start
+    /// The element is positioned at the end of the cell.
+    | End
+    /// The element is positioned at the beginning of the cell.
+    | [<CompiledName "self-start">] SelfStart
+    /// The element is positioned at the end of the cell.
+    | [<CompiledName "self-end">] SelfEnd
+    /// The element is positioned at the left of the cell.
+    | Left
+    /// The element is positioned at the right of the cell.
+    | Right
+
+[<StringEnum; RequireQualifiedAccess>]
 type TextAlignOptions =
     /// Aligns the text to the left.
     | Left
@@ -1132,6 +1160,7 @@ type CSSProp =
     | InlineSize of obj
     | Isolation of obj
     | JustifyContent of obj
+    | JustifySelf of JustifySelfOptions
     | Kerning of obj
     | LayoutGrid of obj
     | LayoutGridChar of obj


### PR DESCRIPTION
Support for CSS JustifySelf  (https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self)

It's still working draft, but we have JustifyContent anyway.
They'll probably move the grid spec to recommendation soon.