### PR TITLE
Fixes webpack ReferenceError for SSRSample

### DIFF
--- a/Samples/SSRSample/webpack.config.js
+++ b/Samples/SSRSample/webpack.config.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var webbpack = require('webpack');
+var webpack = require('webpack');
 const execSync = require("child_process").execSync;
 
 var CONFIG = {


### PR DESCRIPTION
Attempting to launch the SSRSample gives `ReferenceError: webpack is not defined`.