### PR TITLE
New API for FunctionComponent

### DIFF
--- a/Samples/TodoMVC/src/TodoMVC.fs
+++ b/Samples/TodoMVC/src/TodoMVC.fs
@@ -81,14 +81,15 @@ let [<Literal>] COMPLETED_TODOS = "completed"
 
 let TodoItemLabelStyleContext = createContext (fun s -> str s)
 
-let todoItemView (props: {| key: Guid
-                            todo: Todo
-                            editing: bool
-                            onSave: string->unit
-                            onEdit: unit->unit
-                            onDestroy: unit->unit
-                            onCancel: unit->unit
-                            onToggle: unit->unit |}) =
+type TodoItem() =
+  inherit FunctionComponent<{| key: Guid
+                               todo: Todo
+                               editing: bool
+                               onSave: string->unit
+                               onEdit: unit->unit
+                               onDestroy: unit->unit
+                               onCancel: unit->unit
+                               onToggle: unit->unit |}>(fun props ->
     let state = Hooks.useState(props.todo.title)
     let editField: IRefHook<Element option> = Hooks.useRef None
     let labelStyle = Hooks.useContext TodoItemLabelStyleContext
@@ -148,13 +149,13 @@ let todoItemView (props: {| key: Guid
             OnKeyDown handleKeyDown
         ]
     ]
+)
 
-let TodoItem = FunctionComponent.Of todoItemView
-
-let todoFooterView (props: {| count: int
-                              completedCount: int
-                              onClearCompleted: unit->unit
-                              nowShowing: string |}) =
+type TodoFooter() =
+  inherit FunctionComponent<{| count: int
+                               completedCount: int
+                               onClearCompleted: unit->unit
+                               nowShowing: string |}>(fun props ->
     let activeTodoWord =
         "item" + (if props.count = 1 then "" else "s")
     let clearButton =
@@ -183,10 +184,10 @@ let todoFooterView (props: {| count: int
             clearButton
         ]
     ]
+)
 
-let TodoFooter = FunctionComponent.Of todoFooterView
-
-let todoAppView (props: {| model: TodoModel |}) =
+type TodoApp() =
+  inherit FunctionComponent<{| model: TodoModel |}>(fun props ->
     let state = Hooks.useState {| nowShowing = ALL_TODOS
                                   editing = Option<Guid>.None
                                   newTodo = "" |}
@@ -247,7 +248,7 @@ let todoAppView (props: {| model: TodoModel |}) =
             | COMPLETED_TODOS -> todo.completed
             | _ -> true)
         |> Seq.map (fun todo ->
-            TodoItem
+            FunctionComponent.Render<TodoItem,_>
                 {| key = todo.id
                    todo = todo
                    onToggle = fun _ -> toggle(todo)
@@ -268,7 +269,7 @@ let todoAppView (props: {| model: TodoModel |}) =
         todos.Length - activeTodoCount
     let footer =
         if activeTodoCount > 0 || completedCount > 0 then
-            TodoFooter
+            FunctionComponent.Render<TodoFooter,_>
                 {| count = activeTodoCount
                    completedCount = completedCount
                    nowShowing = state.current.nowShowing
@@ -303,14 +304,13 @@ let todoAppView (props: {| model: TodoModel |}) =
         ) [main]
         footer
     ]
-
-let TodoApp = FunctionComponent.Of todoAppView
+)
 
 let model = TodoModel("react-todos")
 
 let render() =
     ReactDom.render(
-        TodoApp {| model = model |},
+        FunctionComponent.Render<TodoApp,_> {| model = model |},
         document.getElementsByClassName("todoapp").[0])
 
 model.subscribe(render)

--- a/Samples/TodoMVC/src/TodoMVC.fs
+++ b/Samples/TodoMVC/src/TodoMVC.fs
@@ -81,15 +81,15 @@ let [<Literal>] COMPLETED_TODOS = "completed"
 
 let TodoItemLabelStyleContext = createContext (fun s -> str s)
 
-type TodoItem() =
-  inherit FunctionComponent<{| key: Guid
-                               todo: Todo
-                               editing: bool
-                               onSave: string->unit
-                               onEdit: unit->unit
-                               onDestroy: unit->unit
-                               onCancel: unit->unit
-                               onToggle: unit->unit |}>(fun props ->
+let TodoItem =
+  FunctionComponent.Of<{| key: Guid
+                          todo: Todo
+                          editing: bool
+                          onSave: string->unit
+                          onEdit: unit->unit
+                          onDestroy: unit->unit
+                          onCancel: unit->unit
+                          onToggle: unit->unit |}>(fun props ->
     let state = Hooks.useState(props.todo.title)
     let editField: IRefHook<Element option> = Hooks.useRef None
     let labelStyle = Hooks.useContext TodoItemLabelStyleContext
@@ -151,11 +151,11 @@ type TodoItem() =
     ]
 )
 
-type TodoFooter() =
-  inherit FunctionComponent<{| count: int
-                               completedCount: int
-                               onClearCompleted: unit->unit
-                               nowShowing: string |}>(fun props ->
+let TodoFooter =
+  FunctionComponent.Of<{| count: int
+                          completedCount: int
+                          onClearCompleted: unit->unit
+                          nowShowing: string |}>(fun props ->
     let activeTodoWord =
         "item" + (if props.count = 1 then "" else "s")
     let clearButton =
@@ -186,8 +186,8 @@ type TodoFooter() =
     ]
 )
 
-type TodoApp() =
-  inherit FunctionComponent<{| model: TodoModel |}>(fun props ->
+let TodoApp =
+ FunctionComponent.Of<{| model: TodoModel |}>(fun props ->
     let state = Hooks.useState {| nowShowing = ALL_TODOS
                                   editing = Option<Guid>.None
                                   newTodo = "" |}
@@ -248,7 +248,7 @@ type TodoApp() =
             | COMPLETED_TODOS -> todo.completed
             | _ -> true)
         |> Seq.map (fun todo ->
-            FunctionComponent.Render<TodoItem,_>
+            TodoItem
                 {| key = todo.id
                    todo = todo
                    onToggle = fun _ -> toggle(todo)
@@ -269,7 +269,7 @@ type TodoApp() =
         todos.Length - activeTodoCount
     let footer =
         if activeTodoCount > 0 || completedCount > 0 then
-            FunctionComponent.Render<TodoFooter,_>
+            TodoFooter
                 {| count = activeTodoCount
                    completedCount = completedCount
                    nowShowing = state.current.nowShowing
@@ -310,7 +310,7 @@ let model = TodoModel("react-todos")
 
 let render() =
     ReactDom.render(
-        FunctionComponent.Render<TodoApp,_> {| model = model |},
+        TodoApp {| model = model |},
         document.getElementsByClassName("todoapp").[0])
 
 model.subscribe(render)

--- a/Samples/TodoMVC/src/TodoMVC.fsproj
+++ b/Samples/TodoMVC/src/TodoMVC.fsproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="3.0.0" />
+    <PackageReference Include="Fable.Core" Version="3.1.5" />
     <PackageReference Include="Fable.Browser.Dom" Version="1.0.0" />
   </ItemGroup>
 

--- a/Samples/TodoMVC/webpack.config.js
+++ b/Samples/TodoMVC/webpack.config.js
@@ -20,7 +20,9 @@ module.exports = {
         contentBase: resolve("./public"),
         port: 8080,
         host: '0.0.0.0',
-        allowedHosts: ['localhost', '.gitpod.io']
+        allowedHosts: ['localhost', '.gitpod.io'],
+        hot: true,
+        inline: true        
     },
     module: {
         rules: [

--- a/src/Fable.React.FunctionComponent.fs
+++ b/src/Fable.React.FunctionComponent.fs
@@ -1,19 +1,75 @@
 namespace Fable.React
 
+open System
 open Fable.Core
 open Fable.Core.JsInterop
 
-type FunctionComponent<'Props> = 'Props -> ReactElement
-type LazyFunctionComponent<'Props> = 'Props -> ReactElement
+module private Cache =
+#if FABLE_COMPILER
+    let private cache = JS.Constructors.Map.Create<obj, ReactElementType>()
+    let getOrAdd<'P> (key: obj) (valueFactory: obj->ReactElementType<'P>): ReactElementType<'P> =
+        if cache.has(key) then cache.get(key) :?> _
+        else let v = valueFactory key in cache.set(key, v) |> ignore; v
+#else
+    let private cache = System.Collections.Concurrent.ConcurrentDictionary<Type, ReactElementType>()
+    let getOrAdd (key: Type) (valueFactory: Type->ReactElementType): ReactElementType =
+        cache.GetOrAdd(key, valueFactory)
+#endif
+
+type FunctionComponentInfo<'P> =
+    { Render: 'P->ReactElement
+      MemoizeWith: ('P->'P->bool) option
+      WithKey: ('P->string) option }
+
+/// A React component that can use hooks to manage the life cycle and is displayed in React dev tools.
+/// Uses React.memo if `memoizeWith` is specified. To optimize collections, use `withKey` argument
+/// or define a `key` field in the props object.
+type FunctionComponent<'P>(render: 'P->ReactElement, ?memoizeWith: 'P->'P->bool, ?withKey: 'P->string) =
+    member __.Info =
+        { Render = render
+          MemoizeWith = memoizeWith
+          WithKey = withKey }
 
 type FunctionComponent =
+#if FABLE_COMPILER
+    static member createElement(constructor: obj, props: 'P) =
+        let getReactElementType (constructor: obj) =
+            let com = createNew constructor () :?> FunctionComponent<'P>
+            let render =
+                let render =
+                    match com.Info.WithKey with
+                    | None -> com.Info.Render
+                    | Some f ->
+                        fun props ->
+                            props?key <- f props
+                            com.Info.Render props
+#if DEBUG
+                render?displayName <- constructor?name
+#endif
+                render
+            match com.Info.MemoizeWith with
+            | Some areEqual -> ReactElementType.memoWith areEqual render
+            | None -> ReactElementType.ofFunction render
+
+        let elType = Cache.getOrAdd constructor getReactElementType
+        ReactElementType.create elType props []
+
+    static member inline Render<'T,'P when 'T :> FunctionComponent<'P> and 'T: (new : unit -> 'T)> (props: 'P): ReactElement =
+        FunctionComponent.createElement(jsConstructor<'T>, props)
+#else
+    static member Render<'T,'P when 'T :> FunctionComponent<'P> and 'T: (new : unit -> 'T)> (props: 'P): ReactElement =
+        let getReactElementType (t: Type) =
+            let com = Activator.CreateInstance(t) :?> FunctionComponent<'P>
+            ReactElementType.ofFunction com.Info.Render :> ReactElementType
+        let elType = Cache.getOrAdd typeof<'T> getReactElementType :?> ReactElementType<'P>
+        ReactElementType.create elType props []
+#endif
+
 #if !FABLE_REPL_LIB
     /// Creates a lazy React component from a function in another file
-    /// ATTENTION: Requires fable-compiler 2.3, pass the external reference
-    /// directly to the argument position (avoid pipes)
-    static member inline Lazy(f: 'Props -> ReactElement,
-                                fallback: ReactElement)
-                            : LazyFunctionComponent<'Props> =
+    /// ATTENTION: Requires fable-compiler 2.3 or above
+    /// Pass the external reference directly into the argument (avoid pipes)
+    static member inline Lazy(f: 'Props -> ReactElement, fallback: ReactElement): 'Props -> ReactElement =
 #if FABLE_COMPILER
         let elemType = ReactBindings.React.``lazy``(fun () ->
             // React.lazy requires a default export
@@ -28,37 +84,3 @@ type FunctionComponent =
             div [] [] // React.lazy is not compatible with SSR, so just use an empty div
 #endif
 #endif
-
-    /// Creates a function React component that can use hooks to manage the component's life cycle,
-    /// and is displayed in React dev tools (use `displayName` to customize the name).
-    /// Uses React.memo if `memoizeWith` is specified (check `equalsButFunctions` and `memoEqualsButFunctions` helpers).
-    /// When you need a key to optimize collections in React you can use `withKey` argument or define a `key` field in the props object.
-    static member Of(render: 'Props->ReactElement,
-                       ?displayName: string,
-                       ?memoizeWith: 'Props -> 'Props -> bool,
-                       ?withKey: 'Props -> string)
-                    : FunctionComponent<'Props> =
-#if FABLE_COMPILER
-        match displayName with
-        | Some name -> render?displayName <- name
-        | None -> ()
-#endif
-        let elemType =
-            match memoizeWith with
-            | Some areEqual ->
-                let memoElement = ReactElementType.memoWith areEqual render
-#if FABLE_COMPILER
-                match displayName with
-                | Some name -> memoElement?displayName <- "Memo(" + name + ")"
-                | None -> ()
-#endif
-                memoElement
-            | None -> ReactElementType.ofFunction render
-        fun props ->
-#if FABLE_COMPILER
-            let props =
-                match withKey with
-                | Some f -> props?key <- f props; props
-                | None -> props
-#endif
-            ReactElementType.create elemType props []

--- a/src/Fable.React.FunctionComponent.fs
+++ b/src/Fable.React.FunctionComponent.fs
@@ -7,6 +7,17 @@ open Fable.Core.JsInterop
 module private Cache =
 #if FABLE_COMPILER
     let private cache = JS.Constructors.Map.Create<obj, ReactElementType>()
+
+// Clear the cache when HMR is fired
+#if DEBUG
+    [<Emit("""try {
+module.hot.addStatusHandler(status =>
+    status === 'ready' ? $0.clear() : null);
+} catch {}""")>]
+    let clearOnHMRUpdates(cache: obj) = ()
+    clearOnHMRUpdates cache
+#endif    
+
     let getOrAdd<'P> (key: obj) (valueFactory: obj->ReactElementType<'P>): ReactElementType<'P> =
         if cache.has(key) then cache.get(key) :?> _
         else let v = valueFactory key in cache.set(key, v) |> ignore; v

--- a/src/Fable.React.Helpers.fs
+++ b/src/Fable.React.Helpers.fs
@@ -182,7 +182,7 @@ module Helpers =
         if obj.ReferenceEquals(x, y) then
             true
         elif isNonEnumerableObject x && not(isNull(box y)) then
-            let keys = JS.Object.keys x
+            let keys = JS.Constructors.Object.keys x
             let length = keys.Count
             let mutable i = 0
             let mutable result = true
@@ -209,7 +209,7 @@ module Helpers =
         if obj.ReferenceEquals(x, y) then
             true
         elif isNonEnumerableObject x && not(isNull(box y)) then
-            let keys = JS.Object.keys x
+            let keys = JS.Constructors.Object.keys x
             let length = keys.Count
             let mutable i = 0
             let mutable result = true

--- a/src/Fable.React.fsproj
+++ b/src/Fable.React.fsproj
@@ -24,7 +24,7 @@
     <Content Include="*.fsproj; *.fs" PackagePath="fable\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="3.0.0" />
+    <PackageReference Include="Fable.Core" Version="3.1.5" />
     <PackageReference Include="Fable.Browser.Dom" Version="1.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
**TL;DR** To use the new API, change the code as follows:

```fsharp
// Declaring site. Before:
let MyComponent = FunctionComponent.Of(fun (props: {| value: string |} -> (* view code *))

// Now (note `displayName` argument is not needed any more):
type MyComponent() =
  inherit FunctionComponent<{| value: string |}>(fun props -> (* view code *))

// Call site. Before:
MyComponent {| value = foo |}

// Now (use type alias if you find it too verbose: `type C = FunctionComponent`)
FunctionComponent.Render<MyComponent,_> {| value = foo |}
```
--------------------
When React hooks were out and functions became the preferred way to define React components, we tried to use the opportunity to move away from the class components as the syntax was a bit messy and promote the use of React components, so the React development tools become more useful in Elmish apps.

However after working in several projects with the `FunctionComponent` helper I've noticed several problems.

- It looks too similar to a simple helper function. This was originally intended to make it easier to use, but unfortunately it makes it much more difficult to see the difference between a React component (that can use hooks and is displayed in the dev tools) and a simple helper function.
- The display name, which is necessary to identify the component in the dev tools, must be passed as a string argument and is easy to forget. When using a lambda the component just appears in the dev tools as "Anonymous".
- Because of F# value restrictions, the compiler complains when using FunctionComponent with props that accept a generic argument. This makes it very cumbersome to use it to build reusable components.

This new proposal for the API solves this problems. Please check how it's applied in the diff for `Samples/TodoMVC/src/TodoMVC.fs`. This is kind of a breaking change, but I've tried to minimize the changes needed to update an existing code base and also I'm keeping the old `Of` method but marking it as deprecated.

![screencast](https://user-images.githubusercontent.com/8275461/77875019-ca662800-7289-11ea-9652-a0f45e81d4cf.gif)
