### PR TITLE
[WIP] ReactComponent attribute

### DIFF
--- a/Samples/TodoMVC/webpack.config.js
+++ b/Samples/TodoMVC/webpack.config.js
@@ -28,7 +28,12 @@ module.exports = {
         rules: [
             {
                 test: /\.fs(x|proj)?$/,
-                use: "fable-loader"
+                use: {
+                    loader: 'fable-loader',
+                    options: {
+                        cli: { path: resolve("../../../fable/src/Fable.Cli/") }
+                    }
+                }
             }
         ]
     },

--- a/src/Fable.React.fsproj
+++ b/src/Fable.React.fsproj
@@ -27,4 +27,7 @@
     <PackageReference Include="Fable.Core" Version="3.1.5" />
     <PackageReference Include="Fable.Browser.Dom" Version="1.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\fable\src\Fable.SimpleAst\Fable.SimpleAst.fsproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
See https://github.com/fable-compiler/Fable/pull/2066

This PR adds a `ReactComponent` attribute that acts as a Fable plugin and can generate some code (with a simplified version of Fable AST) during compile time to overcome the difficulties we've been having to define React components in pure F# code. Basically this attribute transforms a function like this:

```fsharp
module MyComponent

[<ReactComponent>]
let view model dispatch =
    // render code
```

Into something like:

```js
const view = (function () {
   function MyComponent_view($props) {
      const model = $props.model;
      const dispatch = $props.dispatch;
      // render code
   }
   return function(model, dispatch) {
       return react.createElement({ model, dispatch });
   }
}());
```

So we get React-style props and proper naming for free, besides avoiding issue with generic props. The attribute works on module functions and static class member (so we can used named and optional arguments). Also this kind of attribute/plugins can easily be written by other libraries too, like Feliz. Is it cool or is not cool? ;)

![screencast](https://user-images.githubusercontent.com/8275461/83844902-d4e9e580-a742-11ea-8e4f-cce70d41aad4.gif)

@MangelMaxime After making some tests, maybe we can release an alpha/beta version of Fable.React v7 to replace the short lived v6. Although I guess we'll need a blog post and a way to warn the users they need to update their fable-compiler version.