### PR TITLE
Introduce strf

### DIFF
--- a/src/Fable.React.Helpers.fs
+++ b/src/Fable.React.Helpers.fs
@@ -260,6 +260,10 @@ module Helpers =
     /// Cast a string to a React element (erased in runtime)
     let inline ofString (s: string): ReactElement =
         str s
+        
+    /// The equivalent of `sprintf (...) |> str`
+    let inline strf format =
+        Printf.kprintf str format
 
     /// Cast an option value to a React element (erased in runtime)
     let inline ofOption (o: ReactElement option): ReactElement =


### PR DESCRIPTION
A simple shorthand to get rid of an annoying pipe when rendering a formatted string:
`div [] [ sprintf "Hello, %s. It is %A" user DateTime.Now |> str ]`
=>
`div [] [ strf "Hello, %s. It is %A" user DateTime.Now ]`