### PR TITLE
Fallback to original component in FunctionComponent.Lazy for SSR

### DIFF
--- a/src/Fable.React.FunctionComponent.fs
+++ b/src/Fable.React.FunctionComponent.fs
@@ -49,8 +49,7 @@ type FunctionComponent =
                 (createObj ["fallback" ==> fallback])
                 [ReactElementType.create elemType props []]
 #else
-        fun _ ->
-            div [] [] // React.lazy is not compatible with SSR, so just use an empty div
+        f // No React.lazy for SSR, just return component as is
 #endif
 #endif
 


### PR DESCRIPTION
In `FunctionComponet.Lazy` we should not return an empty `div` for SSR. Instead we should return the original component.
Original issue #222 