### PR TITLE
FunctionComponent.Of extend func cache key with 'Props type name

### DIFF
--- a/src/Fable.React/Fable.React.FunctionComponent.fs
+++ b/src/Fable.React/Fable.React.FunctionComponent.fs
@@ -15,9 +15,40 @@ type FunctionComponentPreparedRenderFunctionCache() =
 #endif
         cache
 
-    static member GetOrAdd(key: string, valueFactory: string->'T): 'T =
-        if cache.has(key) then cache.get(key) :?> 'T
-        else let v = valueFactory key in cache.set(key, box v) |> ignore; v
+    static member GetOrAdd(
+            cacheKey: string,
+            displayName: string,
+            render: 'Props -> ReactElement,
+            memoizeWith: ('Props -> 'Props -> bool) option,
+            withKey: ('Props -> string) option,
+            [<CallerMemberName>] ?__callingMemberName: string) =
+        let prepareRenderFunction () =
+            render?displayName <- displayName
+            let elemType =
+                match memoizeWith with
+                | Some areEqual ->
+#if DEBUG
+                    // In development mode, force rerenders always when HMR is fired
+                    let areEqual x y =
+                        not FunctionComponentPreparedRenderFunctionCache.IsHMRApplied && areEqual x y
+#endif
+                    let memoElement = ReactElementType.memoWith areEqual render
+                    memoElement?displayName <- "Memo(" + displayName + ")"
+                    memoElement
+                | None -> ReactElementType.ofFunction render
+            fun props ->
+                let props =
+                    match withKey with
+                    | Some f -> props?key <- f props; props
+                    | None -> props
+                ReactElementType.create elemType props []
+
+        if cache.has(cacheKey) then
+            cache.get(cacheKey) :?> ('Props -> ReactElement)
+        else
+            let v = prepareRenderFunction ()
+            cache.set(cacheKey, box v) |> ignore
+            v
 
     [<Emit("""typeof module === 'object'
 && typeof module.hot === 'object'
@@ -68,28 +99,6 @@ type FunctionComponent =
 #endif
                     ): 'Props -> ReactElement =
 #if FABLE_COMPILER
-        let prepareRenderFunction (_: string) =
-            let displayName = defaultArg displayName __callingMemberName.Value
-            render?displayName <- displayName
-            let elemType =
-                match memoizeWith with
-                | Some areEqual ->
-#if DEBUG
-                    // In development mode, force rerenders always when HMR is fired
-                    let areEqual x y =
-                        not FunctionComponentPreparedRenderFunctionCache.IsHMRApplied && areEqual x y
-#endif
-                    let memoElement = ReactElementType.memoWith areEqual render
-                    memoElement?displayName <- "Memo(" + displayName + ")"
-                    memoElement
-                | None -> ReactElementType.ofFunction render
-            fun props ->
-                let props =
-                    match withKey with
-                    | Some f -> props?key <- f props; props
-                    | None -> props
-                ReactElementType.create elemType props []
-
         // Cache the render function to prevent recreating the component every time when FunctionComponent.Of
         // is called inside another function (including generic values: let MyCom<'T> = ...)
         let cacheKey =
@@ -97,8 +106,9 @@ type FunctionComponent =
             "#L" + (string __callingSourceLine.Value) +
             // direct caller can also be generic, need separate cached func per 'Props argument
             ";" + typeof<'Props>.FullName
+        let displayName = defaultArg displayName __callingMemberName.Value
 
-        FunctionComponentPreparedRenderFunctionCache.GetOrAdd(cacheKey, prepareRenderFunction)
+        FunctionComponentPreparedRenderFunctionCache.GetOrAdd (cacheKey, displayName, render, memoizeWith, withKey)
 #else
         let elemType = ReactElementType.ofFunction render
         fun props ->

--- a/src/Fable.React/Fable.React.fsproj
+++ b/src/Fable.React/Fable.React.fsproj
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>9.4.0</Version>
-    <PackageVersion>9.4.0</PackageVersion>
+    <Version>9.3.0</Version>
+    <PackageVersion>9.3.0</PackageVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <!-- <DefineConstants>$(DefineConstants);FABLE_COMPILER</DefineConstants> -->
     <PackageTags>fsharp;fable;javascript;f#;js;react;fable-library;fable-javascript;fable-dotnet</PackageTags>

--- a/src/Fable.React/Fable.React.fsproj
+++ b/src/Fable.React/Fable.React.fsproj
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>9.3.0</Version>
-    <PackageVersion>9.3.0</PackageVersion>
+    <Version>9.4.0</Version>
+    <PackageVersion>9.4.0</PackageVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <!-- <DefineConstants>$(DefineConstants);FABLE_COMPILER</DefineConstants> -->
     <PackageTags>fsharp;fable;javascript;f#;js;react;fable-library;fable-javascript;fable-dotnet</PackageTags>

--- a/src/Fable.React/RELEASE_NOTES.md
+++ b/src/Fable.React/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 9.4.0
+
+- Fix FunctionComponent's render func caching for generic usages
+
 ### 9.3.0
 
 - Add pointer events to `DOMAttr`


### PR DESCRIPTION
User code that invokes `FunctionComponent.Of` can also be in generic context which makes caching by source FileName+LineNumber unsuitable:  one function gets cached and resolved at runtime for different runtime types which results in runtime exceptions.

I propose to add `'Props` type name to the cache key to fix that.

You still can write code were wrong function will be picked up at runtime for the same 'Props argument type (e.g. if different `render` func values are passed from the outside), but it's less likely to happen. 

Ultimate solution would be to expose the fact that function is prepared and cached to the users and let them to specify their own unique cache key - or piggyback on existing `displayName`, which is also not ideal.